### PR TITLE
Add cross-navigation in all manifest.json

### DIFF
--- a/app/appconfig/fioriSandboxConfig.json
+++ b/app/appconfig/fioriSandboxConfig.json
@@ -17,8 +17,8 @@
                                     "tileType": "sap.ushell.ui.tile.StaticTile",
                                     "properties": {
                                         "targetURL": "#TasksConfig-manage",
-                                        "title": "Manage Task Types",
-                                        "description": "Manage tasks in configuration",
+                                        "title": "Task Types",
+                                        "info": "Configure task types",
                                         "icon": "sap-icon://add-activity"
                                     }
                                 }
@@ -36,8 +36,8 @@
                                     "tileType": "sap.ushell.ui.tile.StaticTile",
                                     "properties": {
                                         "targetURL": "#TaskRuntime-manage",
-                                        "title": "Manage Tasks",
-                                        "description": "Manage tasks in runtime",
+                                        "title": "Tasks",
+                                        "info": "Manage all runtime tasks",
                                         "icon": "sap-icon://activity-assigned-to-goal"
                                     }
                                 },
@@ -46,8 +46,8 @@
                                     "tileType": "sap.ushell.ui.tile.StaticTile",
                                     "properties": {
                                         "targetURL": "#BotInstances-display",
-                                        "title": "Display bot instances",
-                                        "description": "See bots",
+                                        "title": "Bot instances",
+                                        "info": "Display all bot instances",
                                         "icon" : "sap-icon://ai"
                                     }
                                 }

--- a/app/appconfig/fioriSandboxConfig.json
+++ b/app/appconfig/fioriSandboxConfig.json
@@ -71,7 +71,12 @@
                             "action": "manage",
                             "signature": {
                                 "parameters": {
-
+                                    "Tasks.ID": {
+                                        "renameTo": "ID"
+                                    },
+                                    "BotInstances.tasks.ID" : {
+                                        "renameTo" : "ID"
+                                    }
                                 },
                                 "additionalParameters": "allowed"
                             },
@@ -86,7 +91,12 @@
                             "action": "display",
                             "signature": {
                                 "parameters": {
-
+                                    "BotInstances.ID": {
+                                        "renameTo": "ID"
+                                    },
+                                    "Tasks.botInstances.ID" : {
+                                        "renameTo" : "ID"
+                                    }
                                 },
                                 "additionalParameters": "allowed"
                             },

--- a/app/bots-runtime/webapp/i18n/i18n.properties
+++ b/app/bots-runtime/webapp/i18n/i18n.properties
@@ -6,5 +6,8 @@
 appTitle=Bot Instances
 
 #YDES: Application description
-appDescription=Manage all bot instances
+appDescription=Display all bot instances
 
+appInfo=Display all bot instances
+
+appSubTitle=Display all bot instances

--- a/app/bots-runtime/webapp/manifest.json
+++ b/app/bots-runtime/webapp/manifest.json
@@ -18,7 +18,35 @@
                     "odataVersion": "4.0"
                 }
             }
-        }
+        },
+        "crossNavigation": {
+            "inbounds": {
+                "intent1": {
+                "signature": {
+                    "parameters": {
+                        "BotInstances.ID": {
+                            "renameTo": "ID"
+                        },
+                        "Tasks.botInstances.ID" : {
+                            "renameTo" : "ID"
+                        }
+                    },
+                    "additionalParameters": "ignored"
+                },
+                "semanticObject": "BotInstances",
+                "action": "display",
+                "title": "{{appTitle}}",
+                "info": "{{appInfo}}",
+                "subTitle": "{{appSubTitle}}",
+                "icon": "sap-icon://ai",
+                "indicatorDataSource": {
+                    "dataSource": "MainService",
+                    "path": "BotInstances/$count",
+                    "refresh": 1800
+                }
+                }
+            }
+            }
     },
     "sap.ui5": {
         "dependencies": {

--- a/app/task-config/webapp/i18n/i18n.properties
+++ b/app/task-config/webapp/i18n/i18n.properties
@@ -8,3 +8,6 @@ appTitle=Manage Task Types
 #YDES: Application description
 appDescription=Manage all task types
 
+appInfo=Manage all task types
+
+appSubTitle=Manage all task types

--- a/app/task-config/webapp/manifest.json
+++ b/app/task-config/webapp/manifest.json
@@ -18,7 +18,28 @@
 					"odataVersion": "4.0"
 				}
 			}
-		}
+		},
+        "crossNavigation": {
+            "inbounds": {
+                "intent1": {
+                "signature": {
+                    "parameters": {},
+                    "additionalParameters": "ignored"
+                },
+                "semanticObject": "TasksConfig",
+                "action": "manage",
+                "title": "{{appTitle}}",
+                "info": "{{appInfo}}",
+                "subTitle": "{{appSubTitle}}",
+                "icon": "sap-icon://add-activity",
+                "indicatorDataSource": {
+                    "dataSource": "ConfigService",
+                    "path": "TaskTypes/$count",
+                    "refresh": 1800
+                }
+                }
+            }
+            }
 	},
 	"sap.ui5": {
 		"dependencies": {

--- a/app/task-runtime/webapp/i18n/i18n.properties
+++ b/app/task-runtime/webapp/i18n/i18n.properties
@@ -8,3 +8,6 @@ appTitle=Runtime Tasks
 #YDES: Application description
 appDescription=Create and manage runtime tasks
 
+appInfo=Create and manage runtime tasks
+
+appSubTitle=Create and manage runtime tasks

--- a/app/task-runtime/webapp/manifest.json
+++ b/app/task-runtime/webapp/manifest.json
@@ -18,7 +18,35 @@
                     "odataVersion": "4.0"
                 }
             }
-        }
+        },
+        "crossNavigation": {
+            "inbounds": {
+                "intent1": {
+                "signature": {
+                    "parameters": {
+                        "Tasks.ID": {
+                            "renameTo": "ID"
+                        },
+                        "BotInstances.tasks.ID" : {
+                            "renameTo" : "ID"
+                        }
+                    },
+                    "additionalParameters": "ignored"
+                },
+                "semanticObject": "TaskRuntime",
+                "action": "manage",
+                "title": "{{appTitle}}",
+                "info": "{{appInfo}}",
+                "subTitle": "{{appSubTitle}}",
+                "icon": "sap-icon://activity-assigned-to-goal",
+                "indicatorDataSource": {
+                    "dataSource": "MainService",
+                    "path": "Tasks/$count",
+                    "refresh": 1800
+                }
+                }
+            }
+            }
     },
     "sap.ui5": {
         "dependencies": {


### PR DESCRIPTION
The cross navigation currently only works inside the local Fiori Launchpad Sandbox. It is untested if the cross navigation can work without modifying the manifest files upon launching to SAP BTP. It is unsure if the 

However, from existing samples of CAP projects, this is necessary to make sure that it works. Hence, this pull request is created.