### PR TITLE
fix: fixing bug data not shown initially in the TaskDetail

### DIFF
--- a/app/task-runtime/webapp/Component.js
+++ b/app/task-runtime/webapp/Component.js
@@ -1,27 +1,87 @@
-sap.ui.define([
+sap.ui.define(
+  [
     "sap/ui/core/UIComponent",
-    "task-runtime/model/models"
-], (UIComponent, models) => {
+    "task-runtime/model/models",
+    "sap/ui/model/json/JSONModel",
+  ],
+  (UIComponent, models, JSONModel) => {
     "use strict";
 
     return UIComponent.extend("task-runtime.Component", {
-        metadata: {
-            manifest: "json",
-            interfaces: [
-                "sap.ui.core.IAsyncContentCreation"
-            ]
-        },
+      metadata: {
+        manifest: "json",
+        interfaces: ["sap.ui.core.IAsyncContentCreation"],
+      },
 
-        init() {
-            // call the base component's init function
-            UIComponent.prototype.init.apply(this, arguments);
+      init() {
+        // call the base component's init function
+        UIComponent.prototype.init.apply(this, arguments);
 
-            // set the device model
-            this.setModel(models.createDeviceModel(), "device");
+        // set the device model
+        this.setModel(models.createDeviceModel(), "device");
 
-            // enable routing
-            this.getRouter().initialize();
+        const oCNModel = new JSONModel({ nodes: [] });
+        this.setModel(oCNModel, "contextNodes");
+
+        const oBIModel = new JSONModel({ results: [] });
+        this.setModel(oBIModel, "botInstances");
+
+        // enable routing
+        this.getRouter().initialize();
+        this.getRouter().attachRouteMatched(this._onRouteMatched.bind(this));
+      },
+
+      _onRouteMatched: function (oEvent) {
+        const sRoute = oEvent.getParameter("name");
+        const oArgs = oEvent.getParameter("arguments");
+        if (sRoute === "RouteTaskDetail" && oArgs.taskId) {
+          // reuse loader
+          this._loadBotInstances(oArgs.taskId);
+          this._loadContextNodes(oArgs.taskId);
         }
-    });
-});
+      },
 
+      _loadBotInstances: function (taskId) {
+        return this.getModel()
+          .bindList("/Tasks('" + taskId + "')/botInstances")
+          .requestContexts()
+          .then((aCtx) => {
+            const aData = aCtx.map((c) => {
+              const o = c.getObject();
+              o.type = "bot";
+              return o;
+            });
+            this.getModel("botInstances").setData({ results: aData });
+          });
+      },
+
+      _loadContextNodes: function (taskId) {
+        return this.getModel()
+          .bindList("/Tasks('" + taskId + "')/contextNodes")
+          .requestContexts()
+          .then((aCtx) => {
+            const sectionMap = {};
+            aCtx
+              .map((c) => c.getObject())
+              .forEach((item) => {
+                if (!sectionMap[item.path]) {
+                  sectionMap[item.path] = {
+                    path: item.path,
+                    label: item.path.split("/").pop(),
+                    children: [],
+                  };
+                }
+                sectionMap[item.path].children.push({
+                  ID: item.ID,
+                  label: item.label,
+                  value: item.value,
+                  children: [],
+                });
+              });
+            const aRoots = Object.values(sectionMap);
+            this.getModel("contextNodes").setData({ nodes: aRoots });
+          });
+      },
+    });
+  }
+);

--- a/app/task-runtime/webapp/controller/TaskDetail.controller.js
+++ b/app/task-runtime/webapp/controller/TaskDetail.controller.js
@@ -7,103 +7,19 @@ sap.ui.define(
       onInit: function () {
         const oRouter = this.getOwnerComponent().getRouter();
         const oModel = this.getOwnerComponent().getModel();
-
         oRouter.attachRouteMatched(
-          async function (oEvent) {
-            const oArgs = oEvent.getParameter("arguments");
-            if (oArgs && oArgs.taskId) {
-              // Bind the main element first
-              this.getView().bindElement({
-                path: "/Tasks('" + oArgs.taskId + "')",
-              });
-
-              try {
-                // Wait for all data to load before proceeding
-                await Promise.all([
-                  this.loadBotInstances(oArgs.taskId),
-                  this.loadContextNodes(oArgs.taskId),
-                ]);
-
-                // Data is now loaded, you could trigger a refresh here if needed
-              } catch (error) {
-                console.error("Failed to load data:", error);
-              }
-            }
+          function (oEvent) {
+            oModel.refresh();
           }.bind(this)
         );
       },
 
-      loadBotInstances: function (taskId) {
-        const oModel = this.getOwnerComponent().getModel();
-        return oModel
-          .bindList("/Tasks('" + taskId + "')/botInstances")
-          .requestContexts()
-          .then(
-            function (aContexts) {
-              var aData = aContexts.map(function (oContext) {
-                var oObj = oContext.getObject();
-                oObj.type = "bot";
-                return oObj;
-              });
-              const oJSONModel = new JSONModel();
-              oJSONModel.setData({ results: aData });
-              this.getOwnerComponent().setModel(oJSONModel, "botInstances");
-            }.bind(this)
-          );
-      },
-
-      loadContextNodes: function (taskId) {
-        const oModel = this.getOwnerComponent().getModel();
-        return oModel
-          .bindList("/Tasks('" + taskId + "')/contextNodes")
-          .requestContexts()
-          .then(
-            function (aContexts) {
-              const flatData = aContexts.map((ctx) => ctx.getObject());
-              this.buildContextTree(flatData);
-            }.bind(this)
-          );
-      },
-
-      buildContextTree: function (flatList) {
-        // group items by their section path
-        const sectionMap = {};
-        flatList.forEach((item) => {
-          if (!sectionMap[item.path]) {
-            sectionMap[item.path] = {
-              path: item.path,
-              label: item.path.split("/").pop(), // "section1"
-              children: [],
-            };
-          }
-          sectionMap[item.path].children.push({
-            ID: item.ID,
-            label: item.label,
-            value: item.value,
-            children: [],
-          });
-        });
-
-        const roots = Object.values(sectionMap);
-        const oTreeModel = new JSONModel({ nodes: roots });
-        this.getOwnerComponent().setModel(oTreeModel, "tree");
-      },
-
-      getParentPath: function (path) {
-        const lastDot = path.lastIndexOf("/");
-        if (lastDot > 0) return path.substring(0, lastDot);
-        return null;
-      },
-
-      onTreeItemPress: function (oEvent) {
+      onCNItemPress: function (oEvent) {
         // 1) get the pressed item context
         const oItem = oEvent.getParameter("listItem");
-        const oTreeCtx = oItem.getBindingContext("tree");
+
+        const oTreeCtx = oItem.getBindingContext("contextNodes");
         const sUuid = oTreeCtx.getProperty("ID");
-        if (!sUuid) {
-          MessageBox.warning("No ID on this node");
-          return;
-        }
 
         // 2) assemble your read path and fetch full entity
         const sReadPath = `/ContextNodes('${sUuid}')`;
@@ -128,49 +44,7 @@ sap.ui.define(
       },
 
       // ---------------------------------------Context Tree -------------------------------------
-      // This is Detail page
-      onContextNodesSelect: function () {
-        // Get the reference to the author list control by its ID
-        const oList = this.byId("ContextNodesList");
 
-        // Get the currently selected item (author) from the list
-        const oContextNodeSelected = oList.getSelectedItem();
-
-        // If no author is selected, exit the function
-        if (!oContextNodeSelected) {
-          return;
-        }
-
-        // Retrieve the ID of the selected author from its binding context
-        const sContextNodeId = oContextNodeSelected
-          .getBindingContext()
-          .getProperty("ID");
-        console.log(sContextNodeId);
-        // Call a private function to bind and display books related to the selected author
-        this._bindContextNode(sContextNodeId);
-      },
-
-      _bindContextNode: function (sContextNodeId) {
-        // Get a reference to the books table control by its ID
-        const oForm = this.byId("ContextNodeForm");
-        const oOtherForm = this.byId("BotInstanceForm");
-
-        // If no author ID is provided, unbind the table and exit
-        if (!sContextNodeId) {
-          oForm.setVisible(false);
-          oForm.unbindItems();
-          return;
-        } else {
-          oForm.setVisible(true);
-          oOtherForm.setVisible(false);
-          // Bind the table items to the /Books entity set, filtered by the selected author's ID
-          const sPath = "/contextNodes('" + sContextNodeId + "')";
-
-          oForm.bindElement({
-            path: sPath,
-          });
-        }
-      },
       // ---------------------------------------Context Tree -------------------------------------
 
       // -----------------------------------------Task Tree --------------------------------------

--- a/app/task-runtime/webapp/view/Content.fragment.xml
+++ b/app/task-runtime/webapp/view/Content.fragment.xml
@@ -36,17 +36,4 @@
         <Label text="Path" />
         <Text text="{path}" />
     </forms:SimpleForm>
-
-    <forms:SimpleForm
-        visible="false"
-        editable="false"
-        layout="ResponsiveGridLayout"
-        id="BotInstanceForm"
-    >
-        <Label text="ID" />
-        <Text text="{ID}" />
-
-        <Label text="Result" />
-        <Text text="{result}" />
-    </forms:SimpleForm>
 </core:FragmentDefinition>

--- a/app/task-runtime/webapp/view/ContextTree.fragment.xml
+++ b/app/task-runtime/webapp/view/ContextTree.fragment.xml
@@ -14,13 +14,13 @@
             <Tree
                 id="docTree"
                 items="{
-          path: 'tree>/nodes'
+          path: 'contextNodes>/nodes'
         }"
-                itemPress="onTreeItemPress"
-                selectionChange="onTreeItemPress"
+                itemPress=".onCNItemPress"
+                selectionChange=".onCNItemPress"
             >
                 <StandardTreeItem
-                    title="{tree>label}"
+                    title="{contextNodes>label}"
                     type="Active"
                 />
             </Tree>

--- a/app/task-runtime/webapp/view/Details.fragment.xml
+++ b/app/task-runtime/webapp/view/Details.fragment.xml
@@ -6,18 +6,20 @@
     <Toolbar>
         <Title text="Details" />
     </Toolbar>
-    
+
     <!-- Use Flexible Box Layout for better control -->
-    <l:VerticalLayout width="90%" height="100%">
-        
+    <l:VerticalLayout width="90%">
         <!-- Chat Section - Fixed Height -->
-        <l:VerticalLayout width="100%" height="50%" class="topSection">
+        <l:VerticalLayout
+            width="100%"
+            class="topSection"
+        >
             <Title
                 text="AI Chat"
                 level="H4"
                 class="aiChatTitle"
             />
-            
+
             <!-- Chat Messages - Scrollable Area -->
             <ScrollContainer
                 id="chatMessagesContainer"
@@ -33,7 +35,7 @@
                     <!-- Chat messages will be added here dynamically -->
                 </VBox>
             </ScrollContainer>
-            
+
             <!-- Input Box - Fixed at Bottom of Chat Section -->
             <HBox
                 class="chatInputBox"
@@ -57,9 +59,12 @@
                 />
             </HBox>
         </l:VerticalLayout>
-        
+
         <!-- Bottom Section -->
-        <l:VerticalLayout width="100%" height="50%" class="bottomSection">
+        <l:VerticalLayout
+            width="100%"
+            class="bottomSection"
+        >
             <Title
                 text="Code Result"
                 level="H4"
@@ -73,6 +78,5 @@
                 <Text text="Bottom Section Content" />
             </ScrollContainer>
         </l:VerticalLayout>
-        
     </l:VerticalLayout>
 </core:FragmentDefinition>


### PR DESCRIPTION
This PR refactors the way we register and populate our contextNodes and botInstances JSON models to ensure data is always available in TaskDetail, even after a hard browser refresh. Instead of creating and setting these models only in the TaskDetail controller, we now:

1. Register empty JSON models globally in Component.js
2. Hook into the router’s routeMatched event in Component.js to populate both models whenever the RouteTaskDetail is hit