### PR TITLE
fix: update task display logic to show bot instances only when isMain…

### DIFF
--- a/app/task-runtime/webapp/controller/TaskDetail.controller.js
+++ b/app/task-runtime/webapp/controller/TaskDetail.controller.js
@@ -119,7 +119,8 @@ sap.ui.define(
               }.bind(this)
             );
         // If it's not a bot, then it must be a task
-        } else {
+        // If it is a task, only display the bot instances of the task when isMain is false
+        } else if (oContext.getProperty("isMain") == false) {
           const oModel = this.getOwnerComponent().getModel();
           oModel
             .bindList("/Tasks('" + sID + "')/botInstances")


### PR DESCRIPTION
… is false

If the botInstances display a task and the task's isMain is false, then it will not create the node items in the tree. This is necessary to prevent an infinite node tree loop.

![image](https://github.com/user-attachments/assets/f769283e-666c-45c8-a3d9-45085a553721)
