### PR TITLE
Move processing of chatbot to the backend

### DIFF
--- a/app/task-runtime/webapp/controller/TaskDetail.controller.js
+++ b/app/task-runtime/webapp/controller/TaskDetail.controller.js
@@ -1510,7 +1510,7 @@ sap.ui.define(
 
             // // Parsing dan tampilkan response
             // const parsedResponse = this.parseAIResponse(reply);
-            this.addChatMessage(reply, "ai");
+            this.addChatMessage(reply, "assistant");
 
             // Tambahkan ke history lokal
             // this.addToHistory("ai", parsedResponse);
@@ -1591,7 +1591,7 @@ sap.ui.define(
         // Clear existing messages
         this.byId("chatMessagesBox").removeAllItems();
 
-        // Gunakan endpoint OData standard dengan filter
+        // filter based on the botInstance
         var url = `/odata/v4/MainService/BotMessages?$filter=botInstance_ID eq '${botInstanceId}'&$orderby=createdAt asc`;
 
         fetch(url, {
@@ -1616,8 +1616,6 @@ sap.ui.define(
             }
           })
           .catch(function (error) {
-            // Hide busy indicator
-
             console.error("Error loading chat history:", error);
             that.addChatMessage(
               "error",

--- a/app/task-runtime/webapp/controller/TaskDetail.controller.js
+++ b/app/task-runtime/webapp/controller/TaskDetail.controller.js
@@ -62,11 +62,11 @@ sap.ui.define(
           }.bind(this)
         );
 
-        this._chatHistory = [];
-        this._currentMessages = [];
-        this._currentChatId = null;
-        this._loadHistoryFromStorage();
-        this.startNewChat();
+        // this._chatHistory = [];
+        // this._currentMessages = [];
+        // this._currentChatId = null;
+        // this._loadHistoryFromStorage();
+        // this.startNewChat();
 
         // Initialize view model for tree data
         var oViewModel = new JSONModel({
@@ -1325,224 +1325,208 @@ sap.ui.define(
         }
       },
       // ---------------------------------------Chat Bot -------------------------------------
-      conversationHistory: [],
+      // conversationHistory: [],
 
-      parseAIResponse: function (response) {
-        const parts = [];
-        const codeBlockRegex = /```(\w+)?\n?([\s\S]*?)```|`([^`]+)`/g;
+      // parseAIResponse: function (response) {
+      //   const parts = [];
+      //   const codeBlockRegex = /```(\w+)?\n?([\s\S]*?)```|`([^`]+)`/g;
 
-        let lastIndex = 0;
-        let match;
-        let partIndex = 0;
+      //   let lastIndex = 0;
+      //   let match;
+      //   let partIndex = 0;
 
-        while ((match = codeBlockRegex.exec(response)) !== null) {
-          // Add text before the code block
-          if (match.index > lastIndex) {
-            const textBefore = response
-              .substring(lastIndex, match.index)
-              .trim();
-            if (textBefore) {
-              parts.push({
-                type: "text",
-                content: textBefore,
-                index: partIndex++,
-              });
-            }
-          }
+      //   while ((match = codeBlockRegex.exec(response)) !== null) {
+      //     // Add text before the code block
+      //     if (match.index > lastIndex) {
+      //       const textBefore = response
+      //         .substring(lastIndex, match.index)
+      //         .trim();
+      //       if (textBefore) {
+      //         parts.push({
+      //           type: "text",
+      //           content: textBefore,
+      //           index: partIndex++,
+      //         });
+      //       }
+      //     }
 
-          // Add the code block
-          if (match[0].startsWith("```")) {
-            // Multi-line code block
-            parts.push({
-              type: "code_block",
-              language: match[1] || "text",
-              content: match[2] ? match[2].trim() : "",
-              raw: match[0],
-              index: partIndex++,
-            });
-          } else {
-            // Inline code
-            parts.push({
-              type: "inline_code",
-              content: match[3] || "",
-              raw: match[0],
-              index: partIndex++,
-            });
-          }
+      //     // Add the code block
+      //     if (match[0].startsWith("```")) {
+      //       // Multi-line code block
+      //       parts.push({
+      //         type: "code_block",
+      //         language: match[1] || "text",
+      //         content: match[2] ? match[2].trim() : "",
+      //         raw: match[0],
+      //         index: partIndex++,
+      //       });
+      //     } else {
+      //       // Inline code
+      //       parts.push({
+      //         type: "inline_code",
+      //         content: match[3] || "",
+      //         raw: match[0],
+      //         index: partIndex++,
+      //       });
+      //     }
 
-          lastIndex = match.index + match[0].length;
-        }
+      //     lastIndex = match.index + match[0].length;
+      //   }
 
-        // Add remaining text
-        if (lastIndex < response.length) {
-          const remainingText = response.substring(lastIndex).trim();
-          if (remainingText) {
-            parts.push({
-              type: "text",
-              content: remainingText,
-              index: partIndex++,
-            });
-          }
-        }
+      //   // Add remaining text
+      //   if (lastIndex < response.length) {
+      //     const remainingText = response.substring(lastIndex).trim();
+      //     if (remainingText) {
+      //       parts.push({
+      //         type: "text",
+      //         content: remainingText,
+      //         index: partIndex++,
+      //       });
+      //     }
+      //   }
 
-        // If no matches found, return the entire response as text
-        if (parts.length === 0) {
-          parts.push({
-            type: "text",
-            content: response.trim(),
-            index: 0,
-          });
-        }
+      //   // If no matches found, return the entire response as text
+      //   if (parts.length === 0) {
+      //     parts.push({
+      //       type: "text",
+      //       content: response.trim(),
+      //       index: 0,
+      //     });
+      //   }
 
-        return parts;
-      },
+      //   return parts;
+      // },
 
-      // Helper function to convert parsed response back to plain text for history
-      parsedResponseToText: function (parsedResponse) {
-        if (typeof parsedResponse === "string") {
-          return parsedResponse;
-        }
+      // // Helper function to convert parsed response back to plain text for history
+      // parsedResponseToText: function (parsedResponse) {
+      //   if (typeof parsedResponse === "string") {
+      //     return parsedResponse;
+      //   }
 
-        if (Array.isArray(parsedResponse)) {
-          return parsedResponse
-            .map((part) => {
-              if (part.type === "text") {
-                return part.content;
-              } else if (part.type === "code_block") {
-                return `\`\`\`${part.language || ""}\n${part.content}\n\`\`\``;
-              } else if (part.type === "inline_code") {
-                return `\`${part.content}\``;
-              }
-              return part.content || "";
-            })
-            .join("");
-        }
+      //   if (Array.isArray(parsedResponse)) {
+      //     return parsedResponse
+      //       .map((part) => {
+      //         if (part.type === "text") {
+      //           return part.content;
+      //         } else if (part.type === "code_block") {
+      //           return `\`\`\`${part.language || ""}\n${part.content}\n\`\`\``;
+      //         } else if (part.type === "inline_code") {
+      //           return `\`${part.content}\``;
+      //         }
+      //         return part.content || "";
+      //       })
+      //       .join("");
+      //   }
 
-        return String(parsedResponse);
-      },
+      //   return String(parsedResponse);
+      // },
 
-      // Function to manage conversation history
-      addToHistory: function (role, content) {
-        // Convert parsed content to plain text for API
-        const textContent = this.parsedResponseToText(content);
+      // // Function to manage conversation history
+      // addToHistory: function (role, content) {
+      //   // Convert parsed content to plain text for API
+      //   const textContent = this.parsedResponseToText(content);
 
-        this.conversationHistory.push({
-          role: role === "user" ? "user" : "model", // Gemini uses "model" instead of "assistant"
-          parts: [
-            {
-              text: textContent,
-            },
-          ],
-        });
+      //   this.conversationHistory.push({
+      //     role: role === "user" ? "user" : "model", // Gemini uses "model" instead of "assistant"
+      //     parts: [
+      //       {
+      //         text: textContent,
+      //       },
+      //     ],
+      //   });
 
-        // Optional: Limit history to prevent token overflow (keep last 20 exchanges)
-        const maxHistoryLength = 40; // 20 user + 20 AI messages
-        if (this.conversationHistory.length > maxHistoryLength) {
-          this.conversationHistory = this.conversationHistory.slice(
-            -maxHistoryLength
-          );
-        }
-      },
+      //   // Optional: Limit history to prevent token overflow (keep last 20 exchanges)
+      //   const maxHistoryLength = 40; // 20 user + 20 AI messages
+      //   if (this.conversationHistory.length > maxHistoryLength) {
+      //     this.conversationHistory = this.conversationHistory.slice(
+      //       -maxHistoryLength
+      //     );
+      //   }
+      // },
 
-      // Function to clear conversation history
-      clearHistory: function () {
-        this.conversationHistory = [];
-      },
+      // // Function to clear conversation history
+      // clearHistory: function () {
+      //   this.conversationHistory = [];
+      // },
 
-      Query: async function () {
+      onSubmitQuery: async function () {
         var oInput = this.byId("chatInput");
         var sMessage = oInput.getValue().trim();
+
         if (sMessage) {
-          // Add user message
-          this.addChatMessage(sMessage, "user");
-          // Add user message to conversation history
-          this.addToHistory("user", sMessage);
-          // Clear input
-          oInput.setValue("");
-          console.log(sMessage);
-          // Simulate AI response (replace with your actual AI call)
           try {
-            const API_KEY = "AIzaSyDyE_D4ej7SljvLAV5vWMmkQxg5OjGv5r4";
-            const modelonSubmit = "gemini-2.0-flash";
+            // Tampilkan pesan pengguna
+            this.addChatMessage(sMessage, "user");
 
-            // Prepare the request with full conversation history
-            const requestBody = {
-              contents: this.conversationHistory, // Send entire conversation history
-            };
+            // Tambahkan ke history lokal
+            // this.addToHistory("user", sMessage);
 
-            console.log(
-              "Sending conversation history:",
-              this.conversationHistory
-            );
+            // Kosongkan input
+            oInput.setValue("");
 
+            // Tandai sedang loading
+            // this.getView().getModel("ui").setProperty("/busy", true);
+            // ID Bot Instance (ganti dengan cara mendapatkan ID yang sesuai)
+            const botInstanceId = "'880e8400-e29b-41d4-a716-446655440500'"; // Ganti dengan ID yang valid
+
+            // Panggil backend CAP Java
             const response = await fetch(
-              `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${API_KEY}`,
+              `/odata/v4/MainService/BotInstances(${botInstanceId})/MainService.chatCompletion`,
               {
                 method: "POST",
                 headers: {
                   "Content-Type": "application/json",
+                  // Tambahkan CSRF token jika diperlukan
+                  // "X-CSRF-Token": csrfToken
                 },
-                body: JSON.stringify(requestBody),
+                body: JSON.stringify({
+                  content: sMessage,
+                }),
               }
             );
-            console.log(response);
-            const data = await response.json();
-            console.log(data);
-            const reply =
-              data.candidates?.[0]?.content?.parts?.[0]?.text ||
-              "No response from AI.";
 
-            // Check if reply is valid before parsing
-            if (reply && reply !== "No response from AI.") {
-              // Parse the AI response to separate code blocks
-              const parsedResponse = this.parseAIResponse(reply);
-              console.log("Parsed response:", parsedResponse);
+            const resData = await response.json();
+            const reply = resData.value;
 
-              // Add the parsed response to chat
-              this.addChatMessage(parsedResponse, "ai");
+            // Matikan loading
+            // this.getView().getModel("ui").setProperty("/busy", false);
 
-              // Add AI response to conversation history
-              this.addToHistory("ai", parsedResponse);
-            } else {
-              // Fallback to original method if no valid response
-              this.addToHistory("ai", reply);
-              this.addChatMessage(reply, "ai");
-            }
+            // if (!response.ok) {
+            //   throw new Error(`HTTP error ${response.status}`);
+            // }
+
+            // // Parse response
+            // const data = await response.json();
+            // const reply = data.value;
+
+            // // Parsing dan tampilkan response
+            // const parsedResponse = this.parseAIResponse(reply);
+            this.addChatMessage(reply, "ai");
+
+            // Tambahkan ke history lokal
+            // this.addToHistory("ai", parsedResponse);
           } catch (error) {
-            this.addChatMessage("Error: " + error.message, "ai");
-            this.addToHistory("ai", errorMessage);
-            this.addChatMessage(errorMessage, "ai");
+            // Matikan loading
+            // this.getView().getModel("ui").setProperty("/busy", false);
+
+            // this.addChatMessage(errorMessage, "ai");
+            console.error("Error in chat completion:", error);
           }
         }
       },
 
-      // Add these properties to your controller
-      _chatHistory: [], // Array to store chat sessions
-      _currentChatId: null, // Current active chat session ID
-      _currentMessages: [], // Current chat messages
+      // // Add these properties to your controller
+      // _chatHistory: [], // Array to store chat sessions
+      // _currentChatId: null, // Current active chat session ID
+      // _currentMessages: [], // Current chat messages
 
-      // Modified addChatMessage function
+      // // Modified addChatMessage function
       addChatMessage: function (sMessage, sType) {
         var oChatBox = this.byId("chatMessagesBox");
         var sTimestamp = new Date().toLocaleTimeString([], {
           hour: "2-digit",
           minute: "2-digit",
         });
-
-        // Create message object for storage
-        var oMessageData = {
-          id: this._generateMessageId(),
-          message: sMessage,
-          type: sType,
-          timestamp: sTimestamp,
-          fullTimestamp: new Date().toISOString(),
-        };
-
-        // Add to current messages array
-        this._currentMessages.push(oMessageData);
-
-        // Update current chat session in history
-        this._updateCurrentChatInHistory();
 
         var oHTML = new sap.ui.core.HTML({
           content: `
@@ -1555,85 +1539,23 @@ sap.ui.define(
         `,
         });
 
-        // Handle parsed AI responses
+        //   // Handle parsed AI responses
         if (sType === "ai" && Array.isArray(sMessage)) {
-          // Process parsed response parts
-          let textContent = "";
-          let codeBlocks = [];
-
-          sMessage.forEach((part) => {
-            console.log("Processing part:", part);
-            if (part.type === "text") {
-              textContent += part.content + " ";
-            } else if (part.type === "code_block") {
-              codeBlocks.push(part);
-            } else if (part.type === "inline_code") {
-              textContent += `<code>${this.escapeHtml(part.content)}</code> `;
-            }
+          // Handle regular string messages
+          const messageContent =
+            typeof sMessage === "string" ? sMessage : JSON.stringify(sMessage);
+          // create chat bubble if there's text content
+          var oHTML = new sap.ui.core.HTML({
+            content: `
+                    <div class="chatBubbleContainer ${sType}">
+                        <div class="chatBubble ${sType}">
+                            <div>${messageContent}</div>
+                            <div class="chatTimestamp">${sTimestamp}</div>
+                        </div>
+                    </div>
+                `,
           });
-
-          console.log("Processed content:", { textContent, codeBlocks });
-
-          // Update stored message with processed content
-          oMessageData.processedText = textContent.trim();
-          oMessageData.codeBlocks = codeBlocks;
-
-          // Only create chat bubble if there's text content
-          if (textContent.trim()) {
-            var oHTML = new sap.ui.core.HTML({
-              content: `
-                    <div class="chatBubbleContainer ${sType}">
-                        <div class="chatBubble ${sType}">
-                            <div>${textContent.trim()}</div>
-                            <div class="chatTimestamp">${sTimestamp}</div>
-                        </div>
-                    </div>
-                `,
-            });
-            oChatBox.addItem(oHTML);
-          }
-
-          // Handle code blocks separately
-          if (codeBlocks.length > 0) {
-            var oCodeResultText = this.byId("codeResultText");
-            if (oCodeResultText) {
-              const codeSections = codeBlocks.map((block) => {
-                const language = block.language || "code";
-                const langLabel = `<div class="codeLangLabel">${language.toUpperCase()}</div>`;
-                const codeBlock = `
-                        <div class="codeBlockWrapper">
-                            ${langLabel}
-                            <pre><code class="language-${language}">${this.escapeHtml(
-                  block.content
-                )}</code></pre>
-                        </div>
-                    `;
-                return codeBlock;
-              });
-              oCodeResultText.setContent(codeSections.join("<br/>"));
-            }
-          }
-
-          // If no text content and no code blocks, show the original message
-          if (!textContent.trim() && codeBlocks.length === 0) {
-            console.log("No content found, showing original message");
-            const originalMessage = sMessage
-              .map((part) => part.content || part.raw || "")
-              .join(" ");
-            var oHTML = new sap.ui.core.HTML({
-              content: `
-                    <div class="chatBubbleContainer ${sType}">
-                        <div class="chatBubble ${sType}">
-                            <div>${
-                              originalMessage || "AI response received"
-                            }</div>
-                            <div class="chatTimestamp">${sTimestamp}</div>
-                        </div>
-                    </div>
-                `,
-            });
-            oChatBox.addItem(oHTML);
-          }
+          oChatBox.addItem(oHTML);
         } else {
           // Handle regular string messages
           const messageContent =
@@ -1650,327 +1572,308 @@ sap.ui.define(
             `,
           });
           oChatBox.addItem(oHTML);
-
-          // For backward compatibility with non-parsed responses
-          if (sType === "ai" && typeof sMessage === "string") {
-            var oCodeResultText = this.byId("codeResultText");
-            if (oCodeResultText) {
-              oCodeResultText.setText(sMessage);
-            }
-          }
-        }
-
-        // Scroll to bottom
-        setTimeout(() => {
-          var oScrollContainer = this.byId("chatMessagesContainer");
-          if (oScrollContainer && oScrollContainer.getDomRef("scroll")) {
-            oScrollContainer.scrollTo(
-              0,
-              oScrollContainer.getDomRef("scroll").scrollHeight
-            );
-          }
-        }, 100);
-      },
-
-      // Helper function to generate unique message IDs
-      _generateMessageId: function () {
-        return (
-          "msg_" + Date.now() + "_" + Math.random().toString(36).substr(2, 9)
-        );
-      },
-
-      // Helper function to generate unique chat session IDs
-      _generateChatId: function () {
-        return (
-          "chat_" + Date.now() + "_" + Math.random().toString(36).substr(2, 9)
-        );
-      },
-
-      // Function to start a new chat session
-      startNewChat: function () {
-        // Save current chat if it has messages
-        if (this._currentMessages.length > 0) {
-          this._saveChatSession();
-        }
-
-        // Clear current chat
-        this._currentChatId = this._generateChatId();
-        this._currentMessages = [];
-
-        // Clear chat UI
-        var oChatBox = this.byId("chatMessagesBox");
-        if (oChatBox) {
-          oChatBox.destroyItems();
-        }
-
-        // Clear code results
-        var oCodeResultText = this.byId("codeResultText");
-        if (oCodeResultText) {
-          oCodeResultText.setContent("");
         }
       },
 
-      // Function to save current chat session to history
-      _saveChatSession: function () {
-        if (this._currentMessages.length === 0) return;
+      // // Helper function to generate unique message IDs
+      // _generateMessageId: function () {
+      //   return (
+      //     "msg_" + Date.now() + "_" + Math.random().toString(36).substr(2, 9)
+      //   );
+      // },
 
-        var oChatSession = {
-          id: this._currentChatId || this._generateChatId(),
-          title: this._generateChatTitle(),
-          messages: [...this._currentMessages],
-          createdAt: new Date().toISOString(),
-          lastUpdated: new Date().toISOString(),
-        };
+      // // Helper function to generate unique chat session IDs
+      // _generateChatId: function () {
+      //   return (
+      //     "chat_" + Date.now() + "_" + Math.random().toString(36).substr(2, 9)
+      //   );
+      // },
 
-        // Find existing session or add new one
-        var existingIndex = this._chatHistory.findIndex(
-          (chat) => chat.id === oChatSession.id
-        );
-        if (existingIndex >= 0) {
-          this._chatHistory[existingIndex] = oChatSession;
-        } else {
-          this._chatHistory.unshift(oChatSession); // Add to beginning
-        }
+      // // Function to start a new chat session
+      // startNewChat: function () {
+      //   // Save current chat if it has messages
+      //   if (this._currentMessages.length > 0) {
+      //     this._saveChatSession();
+      //   }
 
-        // Limit history to last 50 chats
-        if (this._chatHistory.length > 50) {
-          this._chatHistory = this._chatHistory.slice(0, 50);
-        }
+      //   // Clear current chat
+      //   this._currentChatId = this._generateChatId();
+      //   this._currentMessages = [];
 
-        // Save to local storage for persistence
-        this._saveHistoryToStorage();
-      },
+      //   // Clear chat UI
+      //   var oChatBox = this.byId("chatMessagesBox");
+      //   if (oChatBox) {
+      //     oChatBox.destroyItems();
+      //   }
 
-      // Function to update current chat in history (called after each message)
-      _updateCurrentChatInHistory: function () {
-        if (!this._currentChatId) {
-          this._currentChatId = this._generateChatId();
-        }
-        this._saveChatSession();
-      },
+      //   // Clear code results
+      //   var oCodeResultText = this.byId("codeResultText");
+      //   if (oCodeResultText) {
+      //     oCodeResultText.setContent("");
+      //   }
+      // },
 
-      // Generate a chat title based on first user message
-      _generateChatTitle: function () {
-        var firstUserMessage = this._currentMessages.find(
-          (msg) => msg.type === "user"
-        );
-        if (firstUserMessage) {
-          var title =
-            typeof firstUserMessage.message === "string"
-              ? firstUserMessage.message
-              : "Chat";
-          return title.length > 50 ? title.substring(0, 50) + "..." : title;
-        }
-        return "New Chat - " + new Date().toLocaleDateString();
-      },
+      // // Function to save current chat session to history
+      // _saveChatSession: function () {
+      //   if (this._currentMessages.length === 0) return;
 
-      // Load chat history from storage
-      _loadHistoryFromStorage: function () {
-        try {
-          var storedHistory = localStorage.getItem("chatHistory");
-          if (storedHistory) {
-            this._chatHistory = JSON.parse(storedHistory);
-          }
-        } catch (error) {
-          console.error("Error loading chat history:", error);
-          this._chatHistory = [];
-        }
-      },
+      //   var oChatSession = {
+      //     id: this._currentChatId || this._generateChatId(),
+      //     title: this._generateChatTitle(),
+      //     messages: [...this._currentMessages],
+      //     createdAt: new Date().toISOString(),
+      //     lastUpdated: new Date().toISOString(),
+      //   };
 
-      // Save chat history to storage
-      _saveHistoryToStorage: function () {
-        try {
-          localStorage.setItem(
-            "chatHistory",
-            JSON.stringify(this._chatHistory)
-          );
-        } catch (error) {
-          console.error("Error saving chat history:", error);
-        }
-      },
+      //   // Find existing session or add new one
+      //   var existingIndex = this._chatHistory.findIndex(
+      //     (chat) => chat.id === oChatSession.id
+      //   );
+      //   if (existingIndex >= 0) {
+      //     this._chatHistory[existingIndex] = oChatSession;
+      //   } else {
+      //     this._chatHistory.unshift(oChatSession); // Add to beginning
+      //   }
 
-      // Function to load a specific chat session
-      loadChatSession: function (sChatId) {
-        var oChatSession = this._chatHistory.find(
-          (chat) => chat.id === sChatId
-        );
-        if (!oChatSession) {
-          console.error("Chat session not found:", sChatId);
-          return;
-        }
+      //   // Limit history to last 50 chats
+      //   if (this._chatHistory.length > 50) {
+      //     this._chatHistory = this._chatHistory.slice(0, 50);
+      //   }
 
-        // Save current chat before switching
-        if (this._currentMessages.length > 0) {
-          this._saveChatSession();
-        }
+      //   // Save to local storage for persistence
+      //   this._saveHistoryToStorage();
+      // },
 
-        // Set current chat
-        this._currentChatId = oChatSession.id;
-        this._currentMessages = [...oChatSession.messages];
+      // // Function to update current chat in history (called after each message)
+      // _updateCurrentChatInHistory: function () {
+      //   if (!this._currentChatId) {
+      //     this._currentChatId = this._generateChatId();
+      //   }
+      //   this._saveChatSession();
+      // },
 
-        // Clear and rebuild chat UI
-        this._rebuildChatUI();
+      // // Generate a chat title based on first user message
+      // _generateChatTitle: function () {
+      //   var firstUserMessage = this._currentMessages.find(
+      //     (msg) => msg.type === "user"
+      //   );
+      //   if (firstUserMessage) {
+      //     var title =
+      //       typeof firstUserMessage.message === "string"
+      //         ? firstUserMessage.message
+      //         : "Chat";
+      //     return title.length > 50 ? title.substring(0, 50) + "..." : title;
+      //   }
+      //   return "New Chat - " + new Date().toLocaleDateString();
+      // },
 
-        // Close history dialog
-        this.onCloseChatHistory();
-      },
+      // // Load chat history from storage
+      // _loadHistoryFromStorage: function () {
+      //   try {
+      //     var storedHistory = localStorage.getItem("chatHistory");
+      //     if (storedHistory) {
+      //       this._chatHistory = JSON.parse(storedHistory);
+      //     }
+      //   } catch (error) {
+      //     console.error("Error loading chat history:", error);
+      //     this._chatHistory = [];
+      //   }
+      // },
 
-      // Function to rebuild chat UI from stored messages
-      _rebuildChatUI: function () {
-        var oChatBox = this.byId("chatMessagesBox");
-        var oCodeResultText = this.byId("codeResultText");
+      // // Save chat history to storage
+      // _saveHistoryToStorage: function () {
+      //   try {
+      //     localStorage.setItem(
+      //       "chatHistory",
+      //       JSON.stringify(this._chatHistory)
+      //     );
+      //   } catch (error) {
+      //     console.error("Error saving chat history:", error);
+      //   }
+      // },
 
-        // Clear existing content
-        if (oChatBox) {
-          oChatBox.destroyItems();
-        }
-        if (oCodeResultText) {
-          oCodeResultText.setContent("");
-        }
+      // // Function to load a specific chat session
+      // loadChatSession: function (sChatId) {
+      //   var oChatSession = this._chatHistory.find(
+      //     (chat) => chat.id === sChatId
+      //   );
+      //   if (!oChatSession) {
+      //     console.error("Chat session not found:", sChatId);
+      //     return;
+      //   }
 
-        // Rebuild messages
-        this._currentMessages.forEach((oMessage) => {
-          this._recreateMessageUI(oMessage);
-        });
+      //   // Save current chat before switching
+      //   if (this._currentMessages.length > 0) {
+      //     this._saveChatSession();
+      //   }
 
-        // Scroll to bottom
-        setTimeout(() => {
-          var oScrollContainer = this.byId("chatMessagesContainer");
-          if (oScrollContainer && oScrollContainer.getDomRef("scroll")) {
-            oScrollContainer.scrollTo(
-              0,
-              oScrollContainer.getDomRef("scroll").scrollHeight
-            );
-          }
-        }, 100);
-      },
+      //   // Set current chat
+      //   this._currentChatId = oChatSession.id;
+      //   this._currentMessages = [...oChatSession.messages];
 
-      // Function to recreate message UI from stored data
-      _recreateMessageUI: function (oMessage) {
-        var oChatBox = this.byId("chatMessagesBox");
-        var sType = oMessage.type;
-        var sTimestamp = oMessage.timestamp;
+      //   // Clear and rebuild chat UI
+      //   this._rebuildChatUI();
 
-        if (sType === "ai" && oMessage.processedText !== undefined) {
-          // Handle parsed AI responses
-          if (oMessage.processedText) {
-            var oHTML = new sap.ui.core.HTML({
-              content: `
-                    <div class="chatBubbleContainer ${sType}">
-                        <div class="chatBubble ${sType}">
-                            <div>${oMessage.processedText}</div>
-                            <div class="chatTimestamp">${sTimestamp}</div>
-                        </div>
-                    </div>
-                `,
-            });
-            oChatBox.addItem(oHTML);
-          }
+      //   // Close history dialog
+      //   this.onCloseChatHistory();
+      // },
 
-          // Recreate code blocks
-          if (oMessage.codeBlocks && oMessage.codeBlocks.length > 0) {
-            var oCodeResultText = this.byId("codeResultText");
-            if (oCodeResultText) {
-              const codeSections = oMessage.codeBlocks.map((block) => {
-                const language = block.language || "code";
-                const langLabel = `<div class="codeLangLabel">${language.toUpperCase()}</div>`;
-                const codeBlock = `
-                        <div class="codeBlockWrapper">
-                            ${langLabel}
-                            <pre><code class="language-${language}">${this.escapeHtml(
-                  block.content
-                )}</code></pre>
-                        </div>
-                    `;
-                return codeBlock;
-              });
-              oCodeResultText.setContent(codeSections.join("<br/>"));
-            }
-          }
-        } else {
-          // Handle regular messages
-          const messageContent =
-            typeof oMessage.message === "string"
-              ? oMessage.message
-              : JSON.stringify(oMessage.message);
+      // // Function to rebuild chat UI from stored messages
+      // _rebuildChatUI: function () {
+      //   var oChatBox = this.byId("chatMessagesBox");
+      //   var oCodeResultText = this.byId("codeResultText");
 
-          var oHTML = new sap.ui.core.HTML({
-            content: `
-                <div class="chatBubbleContainer ${sType}">
-                    <div class="chatBubble ${sType}">
-                        <div>${messageContent}</div>
-                        <div class="chatTimestamp">${sTimestamp}</div>
-                    </div>
-                </div>
-            `,
-          });
-          oChatBox.addItem(oHTML);
-        }
-      },
+      //   // Clear existing content
+      //   if (oChatBox) {
+      //     oChatBox.destroyItems();
+      //   }
+      //   if (oCodeResultText) {
+      //     oCodeResultText.setContent("");
+      //   }
 
-      // Enhanced onHistoryPress function
-      onHistoryPress: async function () {
-        // Load history from storage
-        this._loadHistoryFromStorage();
+      //   // Rebuild messages
+      //   this._currentMessages.forEach((oMessage) => {
+      //     this._recreateMessageUI(oMessage);
+      //   });
 
-        if (!this._oHistoryDialog) {
-          this._oHistoryDialog = await Fragment.load({
-            id: this.getView().getId(),
-            name: "task-runtime.view.ChatHistory",
-            controller: this,
-          });
-        }
+      //   // Scroll to bottom
+      //   setTimeout(() => {
+      //     var oScrollContainer = this.byId("chatMessagesContainer");
+      //     if (oScrollContainer && oScrollContainer.getDomRef("scroll")) {
+      //       oScrollContainer.scrollTo(
+      //         0,
+      //         oScrollContainer.getDomRef("scroll").scrollHeight
+      //       );
+      //     }
+      //   }, 100);
+      // },
 
-        // Bind history data to the dialog
-        this._bindHistoryData();
-        this._oHistoryDialog.open();
-      },
+      // // Function to recreate message UI from stored data
+      // _recreateMessageUI: function (oMessage) {
+      //   var oChatBox = this.byId("chatMessagesBox");
+      //   var sType = oMessage.type;
+      //   var sTimestamp = oMessage.timestamp;
 
-      // Function to bind history data to the dialog
-      _bindHistoryData: function () {
-        var oHistoryList = this.byId("chatHistoryList");
-        if (oHistoryList && this._chatHistory.length > 0) {
-          var oModel = new sap.ui.model.json.JSONModel({
-            chatHistory: this._chatHistory,
-          });
-          oHistoryList.setModel(oModel);
-          oHistoryList.bindItems({
-            path: "/chatHistory",
-            template: new sap.m.StandardListItem({
-              title: "{title}",
-              description: "Messages: {/messages/length} • {createdAt}",
-              type: "Active",
-              press: this.onHistoryItemPress.bind(this),
-            }),
-          });
-        }
-      },
+      //   if (sType === "ai" && oMessage.processedText !== undefined) {
+      //     // Handle parsed AI responses
+      //     if (oMessage.processedText) {
+      //       var oHTML = new sap.ui.core.HTML({
+      //         content: `
+      //               <div class="chatBubbleContainer ${sType}">
+      //                   <div class="chatBubble ${sType}">
+      //                       <div>${oMessage.processedText}</div>
+      //                       <div class="chatTimestamp">${sTimestamp}</div>
+      //                   </div>
+      //               </div>
+      //           `,
+      //       });
+      //       oChatBox.addItem(oHTML);
+      //     }
 
-      // Function to handle history item press
-      onHistoryItemPress: function (oEvent) {
-        var oItem = oEvent.getSource();
-        var oContext = oItem.getBindingContext();
-        var oChatData = oContext.getObject();
+      //     // Recreate code blocks
+      //     if (oMessage.codeBlocks && oMessage.codeBlocks.length > 0) {
+      //       var oCodeResultText = this.byId("codeResultText");
+      //       if (oCodeResultText) {
+      //         const codeSections = oMessage.codeBlocks.map((block) => {
+      //           const language = block.language || "code";
+      //           const langLabel = `<div class="codeLangLabel">${language.toUpperCase()}</div>`;
+      //           const codeBlock = `
+      //                   <div class="codeBlockWrapper">
+      //                       ${langLabel}
+      //                       <pre><code class="language-${language}">${this.escapeHtml(
+      //             block.content
+      //           )}</code></pre>
+      //                   </div>
+      //               `;
+      //           return codeBlock;
+      //         });
+      //         oCodeResultText.setContent(codeSections.join("<br/>"));
+      //       }
+      //     }
+      //   } else {
+      //     // Handle regular messages
+      //     const messageContent =
+      //       typeof oMessage.message === "string"
+      //         ? oMessage.message
+      //         : JSON.stringify(oMessage.message);
 
-        // Load the selected chat session
-        this.loadChatSession(oChatData.id);
-      },
+      //     var oHTML = new sap.ui.core.HTML({
+      //       content: `
+      //           <div class="chatBubbleContainer ${sType}">
+      //               <div class="chatBubble ${sType}">
+      //                   <div>${messageContent}</div>
+      //                   <div class="chatTimestamp">${sTimestamp}</div>
+      //               </div>
+      //           </div>
+      //       `,
+      //     });
+      //     oChatBox.addItem(oHTML);
+      //   }
+      // },
 
-      // Helper function to escape HTML (keeping your existing function)
-      escapeHtml: function (text) {
-        const div = document.createElement("div");
-        div.textContent = text;
-        return div.innerHTML;
-      },
+      // // Enhanced onHistoryPress function
+      // onHistoryPress: async function () {
+      //   // Load history from storage
+      //   this._loadHistoryFromStorage();
 
-      // Enhanced onCloseChatHistory function
-      onCloseChatHistory: function () {
-        if (this._oHistoryDialog) {
-          this._oHistoryDialog.close();
-          this._oHistoryDialog.destroy();
-          this._oHistoryDialog = null;
-        }
-      },
+      //   if (!this._oHistoryDialog) {
+      //     this._oHistoryDialog = await Fragment.load({
+      //       id: this.getView().getId(),
+      //       name: "task-runtime.view.ChatHistory",
+      //       controller: this,
+      //     });
+      //   }
+
+      //   // Bind history data to the dialog
+      //   this._bindHistoryData();
+      //   this._oHistoryDialog.open();
+      // },
+
+      // // Function to bind history data to the dialog
+      // _bindHistoryData: function () {
+      //   var oHistoryList = this.byId("chatHistoryList");
+      //   if (oHistoryList && this._chatHistory.length > 0) {
+      //     var oModel = new sap.ui.model.json.JSONModel({
+      //       chatHistory: this._chatHistory,
+      //     });
+      //     oHistoryList.setModel(oModel);
+      //     oHistoryList.bindItems({
+      //       path: "/chatHistory",
+      //       template: new sap.m.StandardListItem({
+      //         title: "{title}",
+      //         description: "Messages: {/messages/length} • {createdAt}",
+      //         type: "Active",
+      //         press: this.onHistoryItemPress.bind(this),
+      //       }),
+      //     });
+      //   }
+      // },
+
+      // // Function to handle history item press
+      // onHistoryItemPress: function (oEvent) {
+      //   var oItem = oEvent.getSource();
+      //   var oContext = oItem.getBindingContext();
+      //   var oChatData = oContext.getObject();
+
+      //   // Load the selected chat session
+      //   this.loadChatSession(oChatData.id);
+      // },
+
+      // // Helper function to escape HTML (keeping your existing function)
+      // escapeHtml: function (text) {
+      //   const div = document.createElement("div");
+      //   div.textContent = text;
+      //   return div.innerHTML;
+      // },
+
+      // // Enhanced onCloseChatHistory function
+      // onCloseChatHistory: function () {
+      //   if (this._oHistoryDialog) {
+      //     this._oHistoryDialog.close();
+      //     this._oHistoryDialog.destroy();
+      //     this._oHistoryDialog = null;
+      //   }
+      // },
       // ---------------------------------------Chat Bot -------------------------------------
     });
   }

--- a/app/task-runtime/webapp/css/style.css
+++ b/app/task-runtime/webapp/css/style.css
@@ -81,7 +81,7 @@
   justify-content: flex-end;
 }
 
-.chatBubbleContainer.ai {
+.chatBubbleContainer.assistant {
   justify-content: flex-start;
 }
 
@@ -100,7 +100,7 @@
   border-bottom-right-radius: 4px;
 }
 
-.chatBubble.ai {
+.chatBubble.assistant {
   background-color: #f1f1f1;
   color: #333;
   border-bottom-left-radius: 4px;
@@ -121,7 +121,7 @@
   margin-bottom: -8px;
 }
 
-.chatBubble.ai::after {
+.chatBubble.assistant::after {
   content: '';
   position: absolute;
   bottom: 0;
@@ -145,7 +145,7 @@
   text-align: right;
 }
 
-.chatBubbleContainer.ai .chatTimestamp {
+.chatBubbleContainer.assistant .chatTimestamp {
   color: #888;
   text-align: left;
 }

--- a/srv/orchestration-service.cds
+++ b/srv/orchestration-service.cds
@@ -16,7 +16,7 @@ service MainService {
             };
             action executeAsync()                        returns Boolean; //用于自动运行, web socket
 
-            action chatCompletion(content : LargeString) returns LargeString;
+            action chatCompletion(content : LargeString) returns BotMessages;
         }
 
     entity BotMessages  as projection on db.BotMessage

--- a/srv/pom.xml
+++ b/srv/pom.xml
@@ -35,6 +35,18 @@
             <artifactId>sqlite-jdbc</artifactId>
             <scope>task-runtime</scope>
         </dependency>
+        <!-- GEMINI AI -->
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-aiplatform</artifactId>
+            <version>3.50.0</version>
+        </dependency>
+        <!-- Jackson untuk JSON handling -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+        </dependency>
     </dependencies>
     <build>
         <finalName>${project.artifactId}</finalName>

--- a/srv/src/main/java/com/sap/cap/ai2code/handlers/chatCompletionHandler.java
+++ b/srv/src/main/java/com/sap/cap/ai2code/handlers/chatCompletionHandler.java
@@ -1,7 +1,42 @@
 package com.sap.cap.ai2code.handlers;
 
-import com.sap.cds.services.handler.EventHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+import com.sap.cap.ai2code.services.GeminiChatService;
+import com.sap.cds.services.handler.EventHandler;
+import com.sap.cds.services.handler.annotations.On;
+import com.sap.cds.services.handler.annotations.ServiceName;
+
+import cds.gen.mainservice.BotInstancesChatCompletionContext;
+
+@Component
+@ServiceName("MainService")
 public class chatCompletionHandler implements EventHandler {
 
+    @Autowired
+    private GeminiChatService geminiChatService;
+
+    /**
+     * Handler untuk chatCompletion action
+     */
+    @On(entity = "MainService.BotInstances", event = "chatCompletion")
+    public void onChatCompletion(BotInstancesChatCompletionContext context) {
+
+        String content = context.getContent();
+        try {
+
+            if (content == null || content.trim().isEmpty()) {
+                context.setResult("Error: No content provided");
+            }
+
+            context.setResult(content);
+
+            String response = geminiChatService.chatCompletion(content);
+
+            context.setResult(response);
+        } catch (Exception e) {
+            context.setResult("Error processing request");
+        }
+    }
 }

--- a/srv/src/main/java/com/sap/cap/ai2code/handlers/chatCompletionHandler.java
+++ b/srv/src/main/java/com/sap/cap/ai2code/handlers/chatCompletionHandler.java
@@ -1,42 +1,337 @@
 package com.sap.cap.ai2code.handlers;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.sap.cap.ai2code.services.GeminiChatService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sap.cds.Result;
+import com.sap.cds.ql.Insert;
+import com.sap.cds.ql.Select;
+import com.sap.cds.ql.Update;
+import com.sap.cds.ql.cqn.CqnInsert;
+import com.sap.cds.ql.cqn.CqnSelect;
+import com.sap.cds.ql.cqn.CqnUpdate;
 import com.sap.cds.services.handler.EventHandler;
 import com.sap.cds.services.handler.annotations.On;
 import com.sap.cds.services.handler.annotations.ServiceName;
+import com.sap.cds.services.persistence.PersistenceService;
 
 import cds.gen.mainservice.BotInstancesChatCompletionContext;
+import cds.gen.mainservice.BotInstances_;
+import cds.gen.mainservice.BotMessages;
+import cds.gen.mainservice.BotMessages_;
 
 @Component
 @ServiceName("MainService")
 public class chatCompletionHandler implements EventHandler {
 
     @Autowired
-    private GeminiChatService geminiChatService;
+    private PersistenceService db;
 
-    /**
-     * Handler untuk chatCompletion action
-     */
-    @On(entity = "MainService.BotInstances", event = "chatCompletion")
-    public void onChatCompletion(BotInstancesChatCompletionContext context) {
+    private final String apiKey = "AIzaSyDyE_D4ej7SljvLAV5vWMmkQxg5OjGv5r4";
+    private final String model = "gemini-2.0-flash";
 
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(30))
+            .build();
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @On(event = BotInstancesChatCompletionContext.CDS_NAME)
+    public void handleChatCompletion(BotInstancesChatCompletionContext context) {
         String content = context.getContent();
+        String aiResponse;
+        String botInstanceId = null;
+
         try {
+            // 1. Set BotInstance status to Running
+            botInstanceId = getBotInstanceAndSetRunning(context);
 
-            if (content == null || content.trim().isEmpty()) {
-                context.setResult("Error: No content provided");
-            }
+            // 2. Check if first conversation or continuing conversation
+            List<BotMessages> messageHistory = getMessageHistory(botInstanceId);
+            boolean isFirstConversation = messageHistory.isEmpty();
 
-            context.setResult(content);
+            // 3. Build message context
+            List<Map<String, String>> conversationContext = buildConversationContext(
+                    messageHistory, content, isFirstConversation);
 
-            String response = geminiChatService.chatCompletion(content);
+            // 4. Call AI API with proper context
+            aiResponse = callGeminiAPIWithContext(conversationContext);
+
+            // 5. Persist user message
+            BotMessages userMsg = BotMessages.create();
+            userMsg.setBotInstanceId(botInstanceId);
+            userMsg.setRole("user");
+            userMsg.setMessage(content);
+            userMsg.setCreatedAt(Instant.now());
+            userMsg.setCreatedBy("user");
+            db.run(Insert.into(BotMessages_.class).entry(userMsg));
+
+            // 6. Persist assistant message & get its ID
+            String assistantMessageId = persistAssistantMessageAndReturnId(botInstanceId, aiResponse);
+
+            // 7. Update status to Success
+            updateBotInstanceStatus(botInstanceId, "S");
+
+            // 8. Buat respons dengan ID yang valid
+            BotMessages response = BotMessages.create();
+            response.setId(assistantMessageId); // Set ID dari pesan yang disimpan
+            response.setRole("assistant");
+            response.setMessage(aiResponse);
+            response.setRagData("AI response from Gemini API");
+            response.setBotInstanceId(botInstanceId);
 
             context.setResult(response);
+
         } catch (Exception e) {
-            context.setResult("Error processing request");
+            System.err.println("Error in chat completion: " + e.getMessage());
+            aiResponse = "Error: " + e.getMessage();
+
+            // Fallback response jika terjadi error
+            BotMessages errorResponse = BotMessages.create();
+            errorResponse.setRole("assistant");
+            errorResponse.setMessage(aiResponse);
+            errorResponse.setRagData("Error response");
+
+            context.setResult(errorResponse);
+
+            // Update status to Failed if we have botInstanceId
+            if (botInstanceId != null) {
+                updateBotInstanceStatus(botInstanceId, "F");
+            }
         }
+    }
+
+    /**
+     * Sets the status of a bot instance to "Running" and returns the
+     * botInstanceId
+     */
+    private String getBotInstanceAndSetRunning(BotInstancesChatCompletionContext context) {
+        CqnSelect selectQuery = context.getCqn();
+        Result botInstanceResult = db.run(selectQuery);
+        String botInstanceId = botInstanceResult.single().get("ID").toString();
+
+        // Update status to Running
+        CqnUpdate updateQuery = Update.entity(BotInstances_.class)
+                .where(b -> b.ID().eq(botInstanceId))
+                .data("status_code", "R");
+        db.run(updateQuery);
+
+        System.out.println("Set Bot Instance " + botInstanceId + " to Running status");
+        return botInstanceId;
+    }
+
+    /**
+     * Gets message history for the bot instance
+     */
+    private List<BotMessages> getMessageHistory(String botInstanceId) {
+        CqnSelect getMessages = Select.from(BotMessages_.class)
+                .where(m -> m.botInstance().ID().eq(botInstanceId))
+                .orderBy(m -> m.createdAt().asc());
+
+        Result messagesResult = db.run(getMessages);
+        List<BotMessages> messageHistory = messagesResult.listOf(BotMessages.class);
+
+        System.out.println("Found " + messageHistory.size() + " previous messages");
+        return messageHistory;
+    }
+
+    /**
+     * Builds conversation context - SIMPLIFIED VERSION: - First conversation:
+     * just user message - Continuing conversation: history + user message
+     */
+    private List<Map<String, String>> buildConversationContext(
+            List<BotMessages> messageHistory, String userMessage, boolean isFirstConversation) {
+
+        List<Map<String, String>> context = new ArrayList<>();
+
+        if (!isFirstConversation) {
+            // Add historical messages to context
+            for (BotMessages msg : messageHistory) {
+                context.add(Map.of(
+                        "role", msg.getRole(),
+                        "content", msg.getMessage()));
+            }
+        }
+
+        // Add current user message
+        context.add(Map.of(
+                "role", "user",
+                "content", userMessage));
+
+        return context;
+    }
+
+    /**
+     * Calls Gemini API with conversation context
+     */
+    private String callGeminiAPIWithContext(List<Map<String, String>> conversationContext) throws Exception {
+        String url = String.format(
+                "https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s",
+                model, apiKey);
+
+        // Build contents array from conversation context
+        StringBuilder contentsBuilder = new StringBuilder();
+        contentsBuilder.append("\"contents\": [");
+
+        for (int i = 0; i < conversationContext.size(); i++) {
+            Map<String, String> message = conversationContext.get(i);
+            String role = message.get("role");
+            String content = message.get("content").replace("\"", "\\\"").replace("\n", "\\n");
+
+            // Gemini uses "user" and "model" roles, map "assistant" and "system" to "model"
+            String geminiRole = "user".equals(role) ? "user" : "model";
+
+            contentsBuilder.append("{")
+                    .append("\"role\": \"").append(geminiRole).append("\",")
+                    .append("\"parts\": [{\"text\": \"").append(content).append("\"}]")
+                    .append("}");
+
+            if (i < conversationContext.size() - 1) {
+                contentsBuilder.append(",");
+            }
+        }
+        contentsBuilder.append("]");
+
+        String requestBody = "{" + contentsBuilder.toString() + "}";
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .timeout(Duration.ofSeconds(30))
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request,
+                HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            throw new RuntimeException("API call failed: " + response.statusCode() + " - " + response.body());
+        }
+
+        return parseGeminiResponse(response.body());
+    }
+
+    /**
+     * Parses Gemini API response
+     */
+    private String parseGeminiResponse(String responseBody) throws Exception {
+        JsonNode jsonResponse = objectMapper.readTree(responseBody);
+        JsonNode candidates = jsonResponse.get("candidates");
+
+        if (candidates != null && candidates.size() > 0) {
+            JsonNode content = candidates.get(0).get("content");
+            if (content != null) {
+                JsonNode parts = content.get("parts");
+                if (parts != null && parts.size() > 0) {
+                    JsonNode text = parts.get(0).get("text");
+                    if (text != null) {
+                        return text.asText();
+                    }
+                }
+            }
+        }
+
+        return "No response from AI";
+    }
+
+    /**
+     * Persists messages to database message + assistant response
+     */
+    private void persistMessages(String botInstanceId, String userMessage, String aiResponse) {
+        List<BotMessages> messagesToInsert = new ArrayList<>();
+        Instant now = Instant.now();
+
+        // Add user message
+        BotMessages userMsg = BotMessages.create();
+        userMsg.setBotInstanceId(botInstanceId);
+        userMsg.setRole("user");
+        userMsg.setMessage(userMessage);
+        userMsg.setCreatedAt(now);
+        userMsg.setCreatedBy("user");
+        messagesToInsert.add(userMsg);
+
+        // Add assistant message
+        BotMessages assistantMsg = BotMessages.create();
+        assistantMsg.setBotInstanceId(botInstanceId);
+        assistantMsg.setRole("assistant");
+        assistantMsg.setMessage(aiResponse);
+        assistantMsg.setCreatedAt(now);
+        assistantMsg.setCreatedBy("system");
+        messagesToInsert.add(assistantMsg);
+
+        // Batch insert all messages
+        if (!messagesToInsert.isEmpty()) {
+            CqnInsert insertMessages = Insert.into(BotMessages_.class).entries(messagesToInsert);
+            db.run(insertMessages);
+            System.out.println("Persisted " + messagesToInsert.size() + " messages");
+        }
+    }
+
+    /**
+     * Updates bot instance status
+     */
+    private void updateBotInstanceStatus(String botInstanceId, String statusCode) {
+        try {
+            CqnUpdate updateQuery = Update.entity(BotInstances_.class)
+                    .where(b -> b.ID().eq(botInstanceId))
+                    .data("status_code", statusCode)
+                    .data("modifiedAt", Instant.now())
+                    .data("modifiedBy", "system");
+
+            db.run(updateQuery);
+
+            String statusName = switch (statusCode) {
+                case "R" ->
+                    "RUNNING";
+                case "S" ->
+                    "SUCCESS";
+                case "F" ->
+                    "FAILED";
+                default ->
+                    statusCode;
+            };
+
+            System.out.println("Updated Bot Instance " + botInstanceId + " status to: " + statusName);
+
+        } catch (Exception e) {
+            System.err.println("Error updating bot instance status: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Persist assistant message dan return ID-nya
+     */
+    private String persistAssistantMessageAndReturnId(String botInstanceId, String aiResponse) {
+        // Generate UUID untuk ID pesan
+        String messageId = UUID.randomUUID().toString();
+
+        // Buat entity untuk assistant message
+        BotMessages assistantMsg = BotMessages.create();
+        assistantMsg.setId(messageId);
+        assistantMsg.setBotInstanceId(botInstanceId);
+        assistantMsg.setRole("assistant");
+        assistantMsg.setMessage(aiResponse);
+        assistantMsg.setCreatedAt(Instant.now());
+        assistantMsg.setCreatedBy("system");
+
+        // Simpan ke database
+        db.run(Insert.into(BotMessages_.class).entry(assistantMsg));
+
+        System.out.println("Persisted assistant message with ID: " + messageId);
+
+        return messageId;
     }
 }

--- a/srv/src/main/java/com/sap/cap/ai2code/services/GeminiChatService.java
+++ b/srv/src/main/java/com/sap/cap/ai2code/services/GeminiChatService.java
@@ -1,0 +1,116 @@
+package com.sap.cap.ai2code.services;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Service
+public class GeminiChatService {
+
+    @Value("${gemini.api.key}")
+    private String apiKey;
+
+    @Value("${gemini.model:gemini-1.5-pro}")
+    private String modelName;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    /**
+     * Fungsi utama untuk chat completion
+     */
+    public String chatCompletion(String content) throws IOException, InterruptedException {
+
+        try {
+            // Buat request body - revisi untuk menghapus SYSTEM role
+            Map<String, Object> requestBody = new HashMap<>();
+
+            // Gunakan struktur yang lebih sederhana untuk Gemini
+            Map<String, Object> contentObj = new HashMap<>();
+
+            List<Map<String, Object>> parts = new ArrayList<>();
+            Map<String, Object> part = new HashMap<>();
+            part.put("text", content);
+            parts.add(part);
+
+            contentObj.put("parts", parts);
+            // Untuk Gemini 1.5 dan 2.0, role USER adalah default jika tidak disebutkan
+            // jadi kita bisa menghilangkan field "role"
+
+            requestBody.put("contents", List.of(contentObj));
+            requestBody.put("generationConfig", createGenerationConfig());
+
+            // Convert to JSON
+            String requestJson = objectMapper.writeValueAsString(requestBody);
+
+            // Create HTTP request
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(String.format(
+                            "https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s",
+                            modelName, apiKey)))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(requestJson))
+                    .build();
+
+            // Send request
+
+            HttpResponse<String> response = httpClient.send(
+                    request, HttpResponse.BodyHandlers.ofString());
+
+            // Check response status
+            int statusCode = response.statusCode();
+
+            if (statusCode != 200) {
+                return "Error from Gemini API: HTTP " + statusCode + " - " + response.body();
+            }
+
+            // Parse response
+            String responseBody = response.body();
+            JsonNode responseJson = objectMapper.readTree(responseBody);
+
+            // Extract text dari response
+            if (responseJson.has("candidates") &&
+                    responseJson.get("candidates").size() > 0 &&
+                    responseJson.get("candidates").get(0).has("content")) {
+
+                String result = responseJson.get("candidates")
+                        .get(0)
+                        .get("content")
+                        .get("parts")
+                        .get(0)
+                        .get("text")
+                        .asText();
+                return result;
+            }
+
+            // Return error message if no valid response
+            return "No response from AI. Error: " + responseJson.toString();
+        } catch (Exception e) {
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Buat konfigurasi generasi untuk API Gemini
+     */
+    private Map<String, Object> createGenerationConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("temperature", 0.7);
+        config.put("maxOutputTokens", 2048);
+        config.put("topP", 0.95);
+        config.put("topK", 40);
+        return config;
+    }
+}

--- a/srv/src/main/resources/application.properties
+++ b/srv/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+# Gemini API Configuration
+gemini.api.key=AIzaSyDyE_D4ej7SljvLAV5vWMmkQxg5OjGv5r4
+gemini.model=gemini-2.0-flash
+
+# Application Configuration
+spring.application.name=chatbot-service
+
+# Logging
+logging.level.com.example.ai.orchestration=INFO

--- a/srv/src/main/resources/application.properties
+++ b/srv/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # Gemini API Configuration
-gemini.api.key=AIzaSyDyE_D4ej7SljvLAV5vWMmkQxg5OjGv5r4
+gemini.api.key=AIzaSyC4sHyZ5EnV5vBpKhdPY_RuJl2x0_ODePw
 gemini.model=gemini-2.0-flash
 
 # Application Configuration


### PR DESCRIPTION
This PR successfully moves the chatbot processing logic from the frontend to the backend 

**Backend Changes**
- Refactored ChatCompletionHandler.java to handle chat requests server-side.
- Integrated logic to store both user and AI responses into the database.
- This enables the chatbot to remember previous messages for context-aware conversations.

Postman Test Results:
![image](https://github.com/user-attachments/assets/cb5164d3-d5f7-46f3-9a9a-3869be4ea925)

The response confirms backend processing is working correctly.

Chat History Example in DB:
![image](https://github.com/user-attachments/assets/8b4cfccc-6812-4c3e-9c44-59249262e455)

Chat context is now preserved through persistent storage.

**Frontend Implementation**
Frontend now only sends the prompt and renders the backend response.

Frontend Screenshot:
![image](https://github.com/user-attachments/assets/3a218740-5f92-4d1b-88cf-ed807d4c0d07)
